### PR TITLE
cache: 1yr immutable Cache-Control on resized images

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -12,7 +12,10 @@ const WHITELISTED_DIMENSIONS = process.env.WHITELISTED_DIMENSIONS
     ? Object.freeze(process.env.WHITELISTED_DIMENSIONS.split(' '))
     : null;
 
-const DEFAULT_CACHE_HEADER = 'public, max-age=86400';
+// Resized image paths are timestamped and immutable — cache aggressively
+// so Cloudflare stops re-pulling the corpus through API Gateway every day.
+const DEFAULT_CACHE_HEADER = 'public, max-age=31536000, immutable';
+const ERROR_CACHE_HEADER = 'private, no-store';
 const FIT_OPTIONS = [
     'cover',    // Preserving aspect ratio, ensure the image covers both provided dimensions by cropping/clipping to fit. (default)
     'contain',  // Preserving aspect ratio, contain within both provided dimensions using "letterboxing" where necessary.
@@ -184,7 +187,7 @@ exports.handler = async (event) => {
         body: "Go away!",
         headers: {
             'Content-Type': 'application/json',
-            'Cache-Control': DEFAULT_CACHE_HEADER,
+            'Cache-Control': ERROR_CACHE_HEADER,
             'Age': 0
         }
     }
@@ -242,7 +245,7 @@ exports.handler = async (event) => {
             body: "Something went wrong",
             headers: {
                 'Content-Type': 'application/json',
-                'Cache-Control': DEFAULT_CACHE_HEADER,
+                'Cache-Control': ERROR_CACHE_HEADER,
                 'Age': 0
             }
         }


### PR DESCRIPTION
Image paths are timestamped/immutable but were served with `max-age=86400`, so Cloudflare re-pulled the entire image corpus through API Gateway every day (~$41/mo of APIGW data-transfer-out, June 2026).

- `DEFAULT_CACHE_HEADER` → `public, max-age=31536000, immutable` (302 redirects + S3 `putObject` metadata)
- 400/500 error responses → `private, no-store` (previously a transient error could be cached for a day; with the new TTL it must never be cacheable)

**Already deployed** to `s3-resizer-dev` and `s3-resizer-prod` on 2026-07-15 (live package was byte-identical to repo HEAD; only `index.js` swapped in the zip). Verified live: fresh resize returns `302` with the 1yr header.

Note: objects resized *before* this change keep `max-age=86400` in their S3 metadata — a Cloudflare Cache Rule (Edge TTL override for `images.aposto.com`) would cover the back catalog too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)